### PR TITLE
Fix authentication problem when wanting to view the details of an account. Fixes #1

### DIFF
--- a/src/main/java/org/com/passdagon/MainController.java
+++ b/src/main/java/org/com/passdagon/MainController.java
@@ -186,34 +186,19 @@ private void loadRequestPasswordWindow() throws IOException, PasswordMismatchExc
 //  sStage.show();
 
   stage.setOnCloseRequest(event -> {
-    Alert alert = new Alert(Alert.AlertType.INFORMATION);
-    alert.setTitle("This alert closes in 1 second");
-    alert.setHeaderText(null);
-    alert.setContentText("This is a sample message.");
-    PauseTransition pause = new PauseTransition(Duration.seconds(1));
-    pause.setOnFinished(eEvent -> alert.close());
-    pause.play();
     System.out.println("returned");
-    if(LoginUtilities.validatePassword(LoginUtilities.password)) {
+    if (LoginUtilities.validatePassword(LoginUtilities.password)) {
       System.out.println("in if");
       LoginUtilities.password = null;
-      stage.show();
+      try {
+        loadDetailsViewWindow();
+      } catch (IOException | PasswordMismatchException e) {
+        throw new RuntimeException(e);
+      }
     } else {
       LoginUtilities.password = null;
     }
-
-
   });
-
-  System.out.println("returned");
-  if(!LoginUtilities.validatePassword(LoginUtilities.password)) {
-    System.out.println("in if");
-    LoginUtilities.password = null;
-    throw new PasswordMismatchException();
-
-  }
-  LoginUtilities.password = null;
-  loadDetailsViewWindow();
 }
 
 }

--- a/src/main/java/org/com/passdagon/MainController.java
+++ b/src/main/java/org/com/passdagon/MainController.java
@@ -1,5 +1,6 @@
 package org.com.passdagon;
 
+import javafx.animation.PauseTransition;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -11,6 +12,7 @@ import javafx.scene.control.*;
 import javafx.scene.layout.AnchorPane;
 import javafx.event.ActionEvent;
 import javafx.stage.Stage;
+import javafx.util.Duration;
 import org.com.passdagon.exceptions.AccountNotPresentException;
 import org.com.passdagon.exceptions.PasswordMismatchException;
 import org.com.passdagon.model.Account;
@@ -147,27 +149,7 @@ public class MainController {
     Scene scene = new Scene(root);
     Stage stage = new Stage();
     stage.setScene(scene);
-
-    FXMLLoader lLoader = new FXMLLoader(getClass().getResource("request-password-view.fxml"));
-    Parent rRoot = lLoader.load();
-
-    Scene sScene = new Scene(rRoot);
-    Stage sStage = new Stage();
-    sStage.setScene(sScene);
-    sStage.show();
-
-    sStage.setOnCloseRequest(event -> {
-      System.out.println("returned");
-      if(LoginUtilities.validatePassword(LoginUtilities.password)) {
-        System.out.println("in if");
-        LoginUtilities.password = null;
-        stage.show();
-      } else {
-        LoginUtilities.password = null;
-      }
-
-
-    });
+    stage.show();
   }
 
 //  private Account filterAccountByAccountNameAndUsername(
@@ -194,6 +176,34 @@ private void loadRequestPasswordWindow() throws IOException, PasswordMismatchExc
   Stage stage = new Stage();
   stage.setScene(scene);
   stage.show();
+
+//  FXMLLoader loader = new FXMLLoader(getClass().getResource("request-password-view.fxml"));
+//  Parent rRoot = lLoader.load();
+//
+//  Scene sScene = new Scene(rRoot);
+//  Stage sStage = new Stage();
+//  sStage.setScene(sScene);
+//  sStage.show();
+
+  stage.setOnCloseRequest(event -> {
+    Alert alert = new Alert(Alert.AlertType.INFORMATION);
+    alert.setTitle("This alert closes in 1 second");
+    alert.setHeaderText(null);
+    alert.setContentText("This is a sample message.");
+    PauseTransition pause = new PauseTransition(Duration.seconds(1));
+    pause.setOnFinished(eEvent -> alert.close());
+    pause.play();
+    System.out.println("returned");
+    if(LoginUtilities.validatePassword(LoginUtilities.password)) {
+      System.out.println("in if");
+      LoginUtilities.password = null;
+      stage.show();
+    } else {
+      LoginUtilities.password = null;
+    }
+
+
+  });
 
   System.out.println("returned");
   if(!LoginUtilities.validatePassword(LoginUtilities.password)) {

--- a/src/main/java/org/com/passdagon/PassDagon.java
+++ b/src/main/java/org/com/passdagon/PassDagon.java
@@ -1,5 +1,6 @@
 package org.com.passdagon;
 
+import javafx.animation.PauseTransition;
 import javafx.application.Application;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXMLLoader;
@@ -8,6 +9,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import javafx.util.Duration;
 import org.com.passdagon.model.User;
 import org.com.passdagon.utilities.LoginUtilities;
 
@@ -49,7 +51,6 @@ public class PassDagon extends Application {
         alert.setTitle("Close");
         alert.setHeaderText("You're about to quit");
         alert.setContentText("Any data saved will be used for authentication to your data");
-
         if(alert.showAndWait().get() == ButtonType.OK && !(User.getInstance().getPassword().isEmpty())) {
           try {
             event.consume();

--- a/src/main/java/org/com/passdagon/RequestPasswordController.java
+++ b/src/main/java/org/com/passdagon/RequestPasswordController.java
@@ -48,20 +48,17 @@ public class RequestPasswordController implements Initializable {
   @FXML
   void checkPassword(ActionEvent event) {
 
-    Alert alert = new Alert(Alert.AlertType.INFORMATION);
-//    alert.setTitle("Authenticati");
-//    alert.setHeaderText("You're about to quit");
-    alert.setContentText("Authenticating...");
-    System.out.println("Password entered");
       if (LoginUtilities.validatePassword(passwordField.getText())) {
         System.out.println("true");
         LoginUtilities.password = passwordField.getText();
 //        ((Stage) requestPasswordAnchorPane.getScene().getWindow()).close();
       } else {
-        Alert aAlert = new Alert(Alert.AlertType.ERROR);
-        aAlert.setTitle("Error");
-        aAlert.setHeaderText("Wrong password");
-        aAlert.setContentText("Failed to authenticate try again.");
+        LoginUtilities.password = null;
+        Alert alert = new Alert(Alert.AlertType.ERROR);
+        alert.setTitle("Error");
+        alert.setHeaderText("Wrong password");
+        alert.setContentText("Failed to authenticate try again.");
+        alert.showAndWait();
       }
   }
 

--- a/src/main/java/org/com/passdagon/RequestPasswordController.java
+++ b/src/main/java/org/com/passdagon/RequestPasswordController.java
@@ -48,17 +48,20 @@ public class RequestPasswordController implements Initializable {
   @FXML
   void checkPassword(ActionEvent event) {
 
+    Alert alert = new Alert(Alert.AlertType.INFORMATION);
+//    alert.setTitle("Authenticati");
+//    alert.setHeaderText("You're about to quit");
+    alert.setContentText("Authenticating...");
     System.out.println("Password entered");
-    System.out.println("Password: " + User.getInstance().getPassword());
       if (LoginUtilities.validatePassword(passwordField.getText())) {
         System.out.println("true");
         LoginUtilities.password = passwordField.getText();
 //        ((Stage) requestPasswordAnchorPane.getScene().getWindow()).close();
       } else {
-        Alert alert = new Alert(Alert.AlertType.ERROR);
-        alert.setTitle("Error");
-        alert.setHeaderText("Wrong password");
-        alert.setContentText("Failed to authenticate try again.");
+        Alert aAlert = new Alert(Alert.AlertType.ERROR);
+        aAlert.setTitle("Error");
+        aAlert.setHeaderText("Wrong password");
+        aAlert.setContentText("Failed to authenticate try again.");
       }
   }
 


### PR DESCRIPTION
Fixes #1

Changes proposed in this pull request:

- Successfully authenticate a user when wanting to check the details of an account.
- Load the account details view when authentication is successful.
- Show an error message when password entered is not correct prompting to try again.